### PR TITLE
Automatic Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,7 @@ jobs:
       - name: Set Environment Variables
         if: ${{ steps.checkReleaseTag.outputs.exists == 'false' }}
         run: |
-          echo "zipFile=${{ env.packageFileName }}_v${{ steps.version.outputs.value }}_VPM".zip >> $GITHUB_ENV
-          echo "unityPackage=${{ env.packageFileName }}_v${{ steps.version.outputs.value }}.unitypackage" >> $GITHUB_ENV
+          echo "zipFile=${{ env.packageFileName }}_v${{ steps.version.outputs.value }}".zip >> $GITHUB_ENV
 
       - name: Create directory and move files
         if: ${{ steps.checkReleaseTag.outputs.exists == 'false' }}
@@ -72,5 +71,4 @@ jobs:
           tag_name: "v${{ steps.version.outputs.value }}"
           files: |
             ${{ env.zipFile }}
-            ${{ env.unityPackage }}
             ./package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 env:
   packageName: "com.adamgryu.inspectorhistory"
   packagePath: "Packages/com.adamgryu.inspectorhistory"
-  packageFileName: "Inspector History"
+  packageFileName: "Inspector_History"
   packageReleaseName: "Inspector History"
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Build Release
+
+on: 
+  workflow_dispatch:
+  push:
+    branches: main
+    paths: package.json
+
+env:
+  packageName: "com.adamgryu.inspectorhistory"
+  packagePath: "Packages/com.adamgryu.inspectorhistory"
+  packageFileName: "Inspector History"
+  packageReleaseName: "Inspector History"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    
+      - name: Checkout
+        uses: actions/checkout@v3
+    
+      - name: Get Version
+        id: version
+        uses: zoexx/github-action-json-file-properties@b9f36ce6ee6fe2680cd3c32b2c62e22eade7e590
+        with: 
+            file_path: "./package.json"
+            prop_path: "version"
+      
+      - name: Generate Tag
+        id: tag
+        run: echo prop="v${{ steps.version.outputs.value }}" >> $GITHUB_OUTPUT
+
+      - name: Check If Release Tag Exists
+        id: checkReleaseTag
+        uses: mukunku/tag-exists-action@v1.2.0
+        with:
+          tag: ${{ steps.tag.outputs.prop }}
+    
+      - name: Set Environment Variables
+        if: ${{ steps.checkReleaseTag.outputs.exists == 'false' }}
+        run: |
+          echo "zipFile=${{ env.packageFileName }}_v${{ steps.version.outputs.value }}_VPM".zip >> $GITHUB_ENV
+          echo "unityPackage=${{ env.packageFileName }}_v${{ steps.version.outputs.value }}.unitypackage" >> $GITHUB_ENV
+
+      - name: Create directory and move files
+        if: ${{ steps.checkReleaseTag.outputs.exists == 'false' }}
+        run: |
+          mkdir -p ${{env.packagePath}}
+          rsync -r --exclude="${{ env.packagePath }}" ./ "${{ env.packagePath }}"/
+        
+      - name: Create Zip
+        if: ${{ steps.checkReleaseTag.outputs.exists == 'false' }}
+        uses: thedoctor0/zip-release@09336613be18a8208dfa66bd57efafd9e2685657
+        with:
+          type: "zip"
+          directory: "${{env.packagePath}}/"
+          filename: "../../${{env.zipFile}}" # make the zip file two directories up, since we start two directories in above
+          exclusions: "*.git* *.github* .gitignore Packages/"
+          
+      - run: find "${{env.packagePath}}" -name \*.meta >> metaList
+        if: ${{ steps.checkReleaseTag.outputs.exists == 'false' }}
+        
+      - name: Make Release
+        if: ${{ steps.checkReleaseTag.outputs.exists == 'false' }}
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
+        with:
+          name: "${{ env.packageReleaseName }} v${{ steps.version.outputs.value }}"
+          tag_name: "v${{ steps.version.outputs.value }}"
+          files: |
+            ${{ env.zipFile }}
+            ${{ env.unityPackage }}
+            ./package.json


### PR DESCRIPTION
This PR adds a workflow that packages InspectorHistory-Unity for use in package management listings. (Specifically VPM)
The workflow generates a new release whenever the version in package.json is incremented, and offers a .zip file as download.

Would be very useful to have on main, so one can directly reference this repo instead of forking it for package manager purposes.

Example listing: https://justbuddy.github.io/vpm-tools/
Example release: https://github.com/JustBuddy/InspectorHistory-Unity/releases/tag/v1.0.0
VPM is a package management system primarily used by the VRChat community. It follows Unity conventions, the zip is just the repo as a .zip for manual installation or VPM reference.

If merged, the workflow might need to be manually run for the initial 1.0.0 release.