### PR TITLE
Refresh the history window when any scene is closed

### DIFF
--- a/Editor/HistoryWindow.cs
+++ b/Editor/HistoryWindow.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using UnityEditor;
+using UnityEditor.SceneManagement;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using UnityEngine.UIElements;
 using Object = UnityEngine.Object;
 
@@ -40,6 +42,17 @@ namespace InspectorHistory {
 
             RefreshElements();
             HistoryData.instance.onChanged += RefreshElements;
+            EditorSceneManager.sceneClosed += OnSceneClosed;
+        }
+
+        private void OnDestroy()
+        {
+            EditorSceneManager.sceneClosed -= OnSceneClosed;
+        }
+
+        private void OnSceneClosed(Scene scene)
+        {
+            RefreshElements();
         }
 
         private void RefreshElements() {

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An editor window that tracks your recent inspector history and makes it easily a
 - Star objects that you want to return to frequently.
 - Double-click an object to open it directly from the history window.
 - Right-click to ping objects from the history.
-- Drag scene objects into a scene object in the history window.
+- Drag scene objects into the history window to make them a child of another object. 
 
 ## Installation
 1. Open the Package Manager, press the `+` button, and select "Add package from git URL."

--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 An editor window that tracks your recent inspector history and makes it easily available.
 
-![image](https://github.com/adamgryu/InspectorHistory-Unity/assets/2540830/adedc963-9070-4739-9c25-2da6d47ba900)
+![InspectorHistoryCaption](https://github.com/adamgryu/InspectorHistory-Unity/assets/2540830/4d602220-b53a-42e2-9d00-f81abd219199)
 
 ### Features
 - Easily return to an object after accidentally clicking away.
 - Drag and drop objects from the history window into the scene or into an inspector field.
-- Pin objects that you want to return to frequently.
+- Star objects that you want to return to frequently.
 - Double-click an object to open it directly from the history window.
 - Right-click to ping objects from the history.
+- Drag scene objects into a scene object in the history window.
 
 ## Installation
 1. Open the Package Manager, press the `+` button, and select "Add package from git URL."


### PR DESCRIPTION
I just saw your post about this plugin on Twitter. It works great!

This small addition refreshes the history when a scene is closed. Depending on your workflow it might not make much difference. But if you regularly load and unload additive scenes it will help keep the history clear.

I haven't gone in-depth on how the refresh works. There might be a better way to remove only the elements from the closed scene.