### PR TITLE
Allow clearing history + Use type name when object name doesn't exist

### DIFF
--- a/Editor/HistoryData.cs
+++ b/Editor/HistoryData.cs
@@ -57,6 +57,19 @@ namespace InspectorHistory {
             onChanged?.Invoke();
         }
 
+        public void Remove(Object activeObject) {
+            if (history.Remove(activeObject)) {
+                onChanged?.Invoke();
+            }
+        }
+
+        public void RemoveAll() {
+            if (history.Count > 0) {
+                history.Clear();
+                onChanged?.Invoke();
+            }
+        }
+
         public void Pin(Object objectToPin) {
             pinned.Add(objectToPin);
             onChanged?.Invoke();

--- a/Editor/HistoryWindow.cs
+++ b/Editor/HistoryWindow.cs
@@ -67,7 +67,8 @@ namespace InspectorHistory {
                     element.style.display = DisplayStyle.Flex;
 
                     // Update the display info.
-                    element.Q<Label>("ObjectLabel").text = elementObj.name;
+                    var nameToUse = !string.IsNullOrWhiteSpace(elementObj.name) ? elementObj.name : $"Unnamed [{elementObj.GetType().Name}]";
+                    element.Q<Label>("ObjectLabel").text = nameToUse;
                     element.Q<Image>("ObjectIcon").image = AssetPreview.GetMiniThumbnail(elementObj);
                     SetClass(element, "Selected", elementObj == Selection.activeObject);
                     SetClass(element, "SceneObj", !EditorUtility.IsPersistent(elementObj));

--- a/Editor/HistoryWindow.cs
+++ b/Editor/HistoryWindow.cs
@@ -156,6 +156,9 @@ namespace InspectorHistory {
             menu.AddItem(new GUIContent("History Preferences"), false, () => {
                 SettingsService.OpenUserPreferences("Preferences/Inspector History");
             });
+            menu.AddItem(new GUIContent("Clear History"), false, () => {
+                HistoryData.instance.RemoveAll();
+            });
         }
     }
 }


### PR DESCRIPTION
Couple features I added to my local copy that I figured I'd contribute back to you!

1. Clear History on right-click menu
![image](https://github.com/adamgryu/InspectorHistory-Unity/assets/1753413/c71da2b3-dab6-44cc-b432-6dc218713417)

2. Show type name when object name doesn't exist, in the form of "Unnamed [Type]"
![image](https://github.com/adamgryu/InspectorHistory-Unity/assets/1753413/a208209c-6ff6-4629-9f56-d4817bb5d681)
